### PR TITLE
feat: Adiciona Elcio Abdalla ao Comitê Científico Internacional

### DIFF
--- a/committees.html
+++ b/committees.html
@@ -200,6 +200,17 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-md-6 col-lg-4">
+                        <div class="card card-committee-enhanced mb-4">
+                            <div class="card-body">
+                                <img src="assets/images/isc/elcio-abdalla.png" alt="Elcio Abdalla" class="member-avatar">
+                                <div class="member-info">
+                                    <h5 class="card-title">Elcio Abdalla</h5>
+                                    <p class="card-text text-muted"><a href="mailto:eabdalla@if.usp.br">eabdalla@if.usp.br</a></p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </section>
 


### PR DESCRIPTION
Adiciona o professor Elcio Abdalla à lista de membros do Comitê Científico Internacional (ISC) na página de comitês.

Inclui as seguintes alterações:
- Adiciona a imagem do professor Elcio Abdalla (usando um avatar padrão).
- Insere as informações de contato do professor na seção correspondente.