### PR TITLE
Refactor file structure to use clean URLs

### DIFF
--- a/abstract-submission/index.html
+++ b/abstract-submission/index.html
@@ -8,8 +8,8 @@
     <title>Abstract Submission | BRICS-AGAC 2025</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="icon" href="assets/images/favicon-placeholder.png" type="image/png">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="icon" href="/assets/images/favicon-placeholder.png" type="image/png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -25,8 +25,8 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="index.html">
-                <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
+            <a class="navbar-brand" href="/">
+                <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
                 <div class="brand-text-container">
                     <h5>BRICS-AGAC 2025</h5>
                     <span>João Pessoa, Brazil</span>
@@ -38,36 +38,36 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">Home</a>
+                        <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="committees.html">Committees</a>
+                        <a class="nav-link" href="/committees/">Committees</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="speakers.html">Speakers</a>
+                        <a class="nav-link" href="/speakers/">Speakers</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="programme.html">Programme</a>
+                        <a class="nav-link" href="/programme/">Programme</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="registration.html">Registration</a>
+                        <a class="nav-link" href="/registration/">Registration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="abstract-submission.html">Abstracts</a>
+                        <a class="nav-link" href="/abstract-submission/">Abstracts</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownLocalInfo" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Local Info
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownLocalInfo">
-                            <li><a class="dropdown-item" href="venue-travel.html">Venue & Travel</a></li>
-                            <li><a class="dropdown-item" href="accommodation.html">Accommodation</a></li>
-                            <li><a class="dropdown-item" href="explore-joao-pessoa.html">Explore João Pessoa</a></li>
-                            <li><a class="dropdown-item" href="bingo-program.html">BINGO Program</a></li>
+                            <li><a class="dropdown-item" href="/venue-travel/">Venue & Travel</a></li>
+                            <li><a class="dropdown-item" href="/accommodation/">Accommodation</a></li>
+                            <li><a class="dropdown-item" href="/explore-joao-pessoa/">Explore João Pessoa</a></li>
+                            <li><a class="dropdown-item" href="/bingo-program/">BINGO Program</a></li>
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">Contact</a>
+                        <a class="nav-link" href="/contact/">Contact</a>
                     </li>
                 </ul>
             </div>
@@ -142,7 +142,7 @@
                     <p>Accepted abstracts will be compiled into the official Book of Abstracts for the symposium. A digital copy will be made available to all registered participants.</p>
                     <p>
                         Link to Book of Abstracts (PDF - available after review and compilation):<br>
-                        <a href="doc/BRICS-AGAC2025-Abstracts-v1.pdf" target="_blank" download class="btn btn-sm btn-outline-secondary d-inline-block mt-1">
+                        <a href="/doc/BRICS-AGAC2025-Abstracts-v1.pdf" target="_blank" download class="btn btn-sm btn-outline-secondary d-inline-block mt-1">
                             <i class="fas fa-book me-2"></i>BRICS-AGAC2025-Abstracts-v1.pdf
                         </a>
                     </p>
@@ -156,7 +156,7 @@
     <!-- Footer -->
     <footer class="footer text-center">
         <div class="container">
-            <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
+            <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
             <p>&copy; 2024-2025 BRICS Association on Gravity, Astrophysics and Cosmology. All rights reserved.</p>
             <p>5th BRICS-AGAC Symposium | João Pessoa, Paraíba, Brazil | December 2025</p>
         </div>
@@ -165,6 +165,6 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <!-- Custom JS -->
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
 </body>
 </html>

--- a/accommodation/index.html
+++ b/accommodation/index.html
@@ -8,9 +8,9 @@
     <title>Accommodation | BRICS-AGAC 2025</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="css/custom-accommodation.css">
-    <link rel="icon" href="assets/images/favicon-placeholder.png" type="image/png">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/css/custom-accommodation.css">
+    <link rel="icon" href="/assets/images/favicon-placeholder.png" type="image/png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -26,8 +26,8 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="index.html">
-                <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
+            <a class="navbar-brand" href="/">
+                <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
                 <div class="brand-text-container">
                     <h5>BRICS-AGAC 2025</h5>
                     <span>João Pessoa, Brazil</span>
@@ -39,36 +39,36 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">Home</a>
+                        <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="committees.html">Committees</a>
+                        <a class="nav-link" href="/committees/">Committees</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="speakers.html">Speakers</a>
+                        <a class="nav-link" href="/speakers/">Speakers</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="programme.html">Programme</a>
+                        <a class="nav-link" href="/programme/">Programme</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="registration.html">Registration</a>
+                        <a class="nav-link" href="/registration/">Registration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="abstract-submission.html">Abstracts</a>
+                        <a class="nav-link" href="/abstract-submission/">Abstracts</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownLocalInfo" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Local Info
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownLocalInfo">
-                            <li><a class="dropdown-item" href="venue-travel.html">Venue & Travel</a></li>
-                            <li><a class="dropdown-item" href="accommodation.html">Accommodation</a></li>
-                            <li><a class="dropdown-item" href="explore-joao-pessoa.html">Explore João Pessoa</a></li>
-                            <li><a class="dropdown-item" href="bingo-program.html">BINGO Program</a></li>
+                            <li><a class="dropdown-item" href="/venue-travel/">Venue & Travel</a></li>
+                            <li><a class="dropdown-item" href="/accommodation/">Accommodation</a></li>
+                            <li><a class="dropdown-item" href="/explore-joao-pessoa/">Explore João Pessoa</a></li>
+                            <li><a class="dropdown-item" href="/bingo-program/">BINGO Program</a></li>
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">Contact</a>
+                        <a class="nav-link" href="/contact/">Contact</a>
                     </li>
                 </ul>
             </div>
@@ -95,15 +95,15 @@
                 <div class="hotel-card" data-hotel="solmar">
                     <div class="hotel-gallery-container">
                         <div class="main-image-container">
-                            <img src="assets/images/hotel_solmar/predio.jpg" class="main-image" alt="Hotel Solmar - Prédio">
+                            <img src="/assets/images/hotel_solmar/predio.jpg" class="main-image" alt="Hotel Solmar - Prédio">
                         </div>
                         <div class="thumbnail-gallery">
-                            <img src="assets/images/hotel_solmar/predio.jpg" class="thumbnail active" alt="Thumbnail - Prédio">
-                            <img src="assets/images/hotel_solmar/quarto1.jpg" class="thumbnail" alt="Thumbnail - Quarto 1">
-                            <img src="assets/images/hotel_solmar/quarto2.jpg" class="thumbnail" alt="Thumbnail - Quarto 2">
-                            <img src="assets/images/hotel_solmar/comida1.jpg" class="thumbnail" alt="Thumbnail - Comida">
-                            <img src="assets/images/hotel_solmar/lazer1.jpg" class="thumbnail" alt="Thumbnail - Lazer 1">
-                            <img src="assets/images/hotel_solmar/lazer2.jpg" class="thumbnail" alt="Thumbnail - Lazer 2">
+                            <img src="/assets/images/hotel_solmar/predio.jpg" class="thumbnail active" alt="Thumbnail - Prédio">
+                            <img src="/assets/images/hotel_solmar/quarto1.jpg" class="thumbnail" alt="Thumbnail - Quarto 1">
+                            <img src="/assets/images/hotel_solmar/quarto2.jpg" class="thumbnail" alt="Thumbnail - Quarto 2">
+                            <img src="/assets/images/hotel_solmar/comida1.jpg" class="thumbnail" alt="Thumbnail - Comida">
+                            <img src="/assets/images/hotel_solmar/lazer1.jpg" class="thumbnail" alt="Thumbnail - Lazer 1">
+                            <img src="/assets/images/hotel_solmar/lazer2.jpg" class="thumbnail" alt="Thumbnail - Lazer 2">
                         </div>
                     </div>
                     <div class="hotel-info">
@@ -119,15 +119,15 @@
                 <div class="hotel-card" data-hotel="numar">
                     <div class="hotel-gallery-container">
                         <div class="main-image-container">
-                            <img src="assets/images/hotel_numar/predio.jpg" class="main-image" alt="Hotel Numar - Prédio">
+                            <img src="/assets/images/hotel_numar/predio.jpg" class="main-image" alt="Hotel Numar - Prédio">
                         </div>
                         <div class="thumbnail-gallery">
-                            <img src="assets/images/hotel_numar/predio.jpg" class="thumbnail active" alt="Thumbnail - Prédio">
-                            <img src="assets/images/hotel_numar/quarto1.jpg" class="thumbnail" alt="Thumbnail - Quarto 1">
-                            <img src="assets/images/hotel_numar/quarto2.jpg" class="thumbnail" alt="Thumbnail - Quarto 2">
-                            <img src="assets/images/hotel_numar/comida1.jpg" class="thumbnail" alt="Thumbnail - Comida">
-                            <img src="assets/images/hotel_numar/lazer1.jpg" class="thumbnail" alt="Thumbnail - Lazer 1">
-                            <img src="assets/images/hotel_numar/lazer2.jpg" class="thumbnail" alt="Thumbnail - Lazer 2">
+                            <img src="/assets/images/hotel_numar/predio.jpg" class="thumbnail active" alt="Thumbnail - Prédio">
+                            <img src="/assets/images/hotel_numar/quarto1.jpg" class="thumbnail" alt="Thumbnail - Quarto 1">
+                            <img src="/assets/images/hotel_numar/quarto2.jpg" class="thumbnail" alt="Thumbnail - Quarto 2">
+                            <img src="/assets/images/hotel_numar/comida1.jpg" class="thumbnail" alt="Thumbnail - Comida">
+                            <img src="/assets/images/hotel_numar/lazer1.jpg" class="thumbnail" alt="Thumbnail - Lazer 1">
+                            <img src="/assets/images/hotel_numar/lazer2.jpg" class="thumbnail" alt="Thumbnail - Lazer 2">
                         </div>
                     </div>
                     <div class="hotel-info">
@@ -142,15 +142,15 @@
                 <div class="hotel-card" data-hotel="annamar">
                     <div class="hotel-gallery-container">
                         <div class="main-image-container">
-                            <img src="assets/images/hotel_annamar/predio.jpg" class="main-image" alt="Hotel Annamar - Prédio">
+                            <img src="/assets/images/hotel_annamar/predio.jpg" class="main-image" alt="Hotel Annamar - Prédio">
                         </div>
                         <div class="thumbnail-gallery">
-                            <img src="assets/images/hotel_annamar/predio.jpg" class="thumbnail active" alt="Thumbnail - Prédio">
-                            <img src="assets/images/hotel_annamar/quarto1.jpg" class="thumbnail" alt="Thumbnail - Quarto 1">
-                            <img src="assets/images/hotel_annamar/quarto2.jpg" class="thumbnail" alt="Thumbnail - Quarto 2">
-                            <img src="assets/images/hotel_annamar/comida1.jpg" class="thumbnail" alt="Thumbnail - Comida">
-                            <img src="assets/images/hotel_annamar/lazer1.jpg" class="thumbnail" alt="Thumbnail - Lazer 1">
-                            <img src="assets/images/hotel_annamar/lazer2.jpg" class="thumbnail" alt="Thumbnail - Lazer 2">
+                            <img src="/assets/images/hotel_annamar/predio.jpg" class="thumbnail active" alt="Thumbnail - Prédio">
+                            <img src="/assets/images/hotel_annamar/quarto1.jpg" class="thumbnail" alt="Thumbnail - Quarto 1">
+                            <img src="/assets/images/hotel_annamar/quarto2.jpg" class="thumbnail" alt="Thumbnail - Quarto 2">
+                            <img src="/assets/images/hotel_annamar/comida1.jpg" class="thumbnail" alt="Thumbnail - Comida">
+                            <img src="/assets/images/hotel_annamar/lazer1.jpg" class="thumbnail" alt="Thumbnail - Lazer 1">
+                            <img src="/assets/images/hotel_annamar/lazer2.jpg" class="thumbnail" alt="Thumbnail - Lazer 2">
                         </div>
                     </div>
                     <div class="hotel-info">
@@ -165,15 +165,15 @@
                 <div class="hotel-card" data-hotel="litoral">
                     <div class="hotel-gallery-container">
                         <div class="main-image-container">
-                            <img src="assets/images/hotel_littoral/predio.jpg" class="main-image" alt="Hotel Litoral - Prédio">
+                            <img src="/assets/images/hotel_littoral/predio.jpg" class="main-image" alt="Hotel Litoral - Prédio">
                         </div>
                         <div class="thumbnail-gallery">
-                            <img src="assets/images/hotel_littoral/predio.jpg" class="thumbnail active" alt="Thumbnail - Prédio">
-                            <img src="assets/images/hotel_littoral/quarto1.jpg" class="thumbnail" alt="Thumbnail - Quarto 1">
-                            <img src="assets/images/hotel_littoral/quarto2.jpg" class="thumbnail" alt="Thumbnail - Quarto 2">
-                            <img src="assets/images/hotel_littoral/comida1.jpg" class="thumbnail" alt="Thumbnail - Comida">
-                            <img src="assets/images/hotel_littoral/lazer1.jpg" class="thumbnail" alt="Thumbnail - Lazer 1">
-                            <img src="assets/images/hotel_littoral/lazer2.jpg" class="thumbnail" alt="Thumbnail - Lazer 2">
+                            <img src="/assets/images/hotel_littoral/predio.jpg" class="thumbnail active" alt="Thumbnail - Prédio">
+                            <img src="/assets/images/hotel_littoral/quarto1.jpg" class="thumbnail" alt="Thumbnail - Quarto 1">
+                            <img src="/assets/images/hotel_littoral/quarto2.jpg" class="thumbnail" alt="Thumbnail - Quarto 2">
+                            <img src="/assets/images/hotel_littoral/comida1.jpg" class="thumbnail" alt="Thumbnail - Comida">
+                            <img src="/assets/images/hotel_littoral/lazer1.jpg" class="thumbnail" alt="Thumbnail - Lazer 1">
+                            <img src="/assets/images/hotel_littoral/lazer2.jpg" class="thumbnail" alt="Thumbnail - Lazer 2">
                         </div>
                     </div>
                     <div class="hotel-info">
@@ -189,15 +189,15 @@
                 <div class="hotel-card" data-hotel="way">
                     <div class="hotel-gallery-container">
                         <div class="main-image-container">
-                            <img src="assets/images/hotel_way/predio.jpg" class="main-image" alt="Edifício Way - Prédio">
+                            <img src="/assets/images/hotel_way/predio.jpg" class="main-image" alt="Edifício Way - Prédio">
                         </div>
                         <div class="thumbnail-gallery">
-                            <img src="assets/images/hotel_way/predio.jpg" class="thumbnail active" alt="Thumbnail - Prédio">
-                            <img src="assets/images/hotel_way/quarto1.jpg" class="thumbnail" alt="Thumbnail - Quarto 1">
-                            <img src="assets/images/hotel_way/quarto2.jpg" class="thumbnail" alt="Thumbnail - Quarto 2">
-                            <img src="assets/images/hotel_way/comida1.jpg" class="thumbnail" alt="Thumbnail - Comida">
-                            <img src="assets/images/hotel_way/lazer1.jpg" class="thumbnail" alt="Thumbnail - Lazer 1">
-                            <img src="assets/images/hotel_way/lazer2.jpg" class="thumbnail" alt="Thumbnail - Lazer 2">
+                            <img src="/assets/images/hotel_way/predio.jpg" class="thumbnail active" alt="Thumbnail - Prédio">
+                            <img src="/assets/images/hotel_way/quarto1.jpg" class="thumbnail" alt="Thumbnail - Quarto 1">
+                            <img src="/assets/images/hotel_way/quarto2.jpg" class="thumbnail" alt="Thumbnail - Quarto 2">
+                            <img src="/assets/images/hotel_way/comida1.jpg" class="thumbnail" alt="Thumbnail - Comida">
+                            <img src="/assets/images/hotel_way/lazer1.jpg" class="thumbnail" alt="Thumbnail - Lazer 1">
+                            <img src="/assets/images/hotel_way/lazer2.jpg" class="thumbnail" alt="Thumbnail - Lazer 2">
                         </div>
                     </div>
                     <div class="hotel-info">
@@ -226,7 +226,7 @@
     <!-- Footer -->
     <footer class="footer text-center">
         <div class="container">
-            <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
+            <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
             <p>&copy; 2024-2025 BRICS Association on Gravity, Astrophysics and Cosmology. All rights reserved.</p>
             <p>5th BRICS-AGAC Symposium | João Pessoa, Paraíba, Brazil | December 2025</p>
         </div>
@@ -235,7 +235,7 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <!-- Custom JS -->
-    <script src="js/script.js"></script>
-    <script src="js/accommodation-carousel.js"></script>
+    <script src="/js/script.js"></script>
+    <script src="/js/accommodation-carousel.js"></script>
 </body>
 </html>

--- a/bingo-program/index.html
+++ b/bingo-program/index.html
@@ -8,8 +8,8 @@
     <title>BINGO Program | BRICS-AGAC 2025</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="icon" href="assets/images/favicon-placeholder.png" type="image/png">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="icon" href="/assets/images/favicon-placeholder.png" type="image/png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -25,8 +25,8 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="index.html">
-                <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
+            <a class="navbar-brand" href="/">
+                <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
                 <div class="brand-text-container">
                     <h5>BRICS-AGAC 2025</h5>
                     <span>João Pessoa, Brazil</span>
@@ -38,36 +38,36 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">Home</a>
+                        <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="committees.html">Committees</a>
+                        <a class="nav-link" href="/committees/">Committees</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="speakers.html">Speakers</a>
+                        <a class="nav-link" href="/speakers/">Speakers</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="programme.html">Programme</a>
+                        <a class="nav-link" href="/programme/">Programme</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="registration.html">Registration</a>
+                        <a class="nav-link" href="/registration/">Registration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="abstract-submission.html">Abstracts</a>
+                        <a class="nav-link" href="/abstract-submission/">Abstracts</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownLocalInfo" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Local Info
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownLocalInfo">
-                            <li><a class="dropdown-item" href="venue-travel.html">Venue & Travel</a></li>
-                            <li><a class="dropdown-item" href="accommodation.html">Accommodation</a></li>
-                            <li><a class="dropdown-item" href="explore-joao-pessoa.html">Explore João Pessoa</a></li>
-                            <li><a class="dropdown-item" href="bingo-program.html">BINGO Program</a></li>
+                            <li><a class="dropdown-item" href="/venue-travel/">Venue & Travel</a></li>
+                            <li><a class="dropdown-item" href="/accommodation/">Accommodation</a></li>
+                            <li><a class="dropdown-item" href="/explore-joao-pessoa/">Explore João Pessoa</a></li>
+                            <li><a class="dropdown-item" href="/bingo-program/">BINGO Program</a></li>
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">Contact</a>
+                        <a class="nav-link" href="/contact/">Contact</a>
                     </li>
                 </ul>
             </div>
@@ -116,7 +116,7 @@
     <!-- Footer -->
     <footer class="footer text-center">
         <div class="container">
-            <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
+            <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
             <p>&copy; 2024-2025 BRICS Association on Gravity, Astrophysics and Cosmology. All rights reserved.</p>
             <p>5th BRICS-AGAC Symposium | João Pessoa, Paraíba, Brazil | December 2025</p>
         </div>
@@ -125,6 +125,6 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <!-- Custom JS -->
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
 </body>
 </html>

--- a/committees/index.html
+++ b/committees/index.html
@@ -8,8 +8,8 @@
     <title>Committees | BRICS-AGAC 2025</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="icon" href="assets/images/favicon-placeholder.png" type="image/png">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="icon" href="/assets/images/favicon-placeholder.png" type="image/png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -25,8 +25,8 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="index.html">
-                <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
+            <a class="navbar-brand" href="/">
+                <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
                 <div class="brand-text-container">
                     <h5>BRICS-AGAC 2025</h5>
                     <span>João Pessoa, Brazil</span>
@@ -38,36 +38,36 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">Home</a>
+                        <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="committees.html">Committees</a>
+                        <a class="nav-link" href="/committees/">Committees</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="speakers.html">Speakers</a>
+                        <a class="nav-link" href="/speakers/">Speakers</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="programme.html">Programme</a>
+                        <a class="nav-link" href="/programme/">Programme</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="registration.html">Registration</a>
+                        <a class="nav-link" href="/registration/">Registration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="abstract-submission.html">Abstracts</a>
+                        <a class="nav-link" href="/abstract-submission/">Abstracts</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownLocalInfo" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Local Info
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownLocalInfo">
-                            <li><a class="dropdown-item" href="venue-travel.html">Venue & Travel</a></li>
-                            <li><a class="dropdown-item" href="accommodation.html">Accommodation</a></li>
-                            <li><a class="dropdown-item" href="explore-joao-pessoa.html">Explore João Pessoa</a></li>
-                            <li><a class="dropdown-item" href="bingo-program.html">BINGO Program</a></li>
+                            <li><a class="dropdown-item" href="/venue-travel/">Venue & Travel</a></li>
+                            <li><a class="dropdown-item" href="/accommodation/">Accommodation</a></li>
+                            <li><a class="dropdown-item" href="/explore-joao-pessoa/">Explore João Pessoa</a></li>
+                            <li><a class="dropdown-item" href="/bingo-program/">BINGO Program</a></li>
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">Contact</a>
+                        <a class="nav-link" href="/contact/">Contact</a>
                     </li>
                 </ul>
             </div>
@@ -92,7 +92,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/elcio-abdalla.png" alt="Elcio Abdalla" class="member-avatar">
+                                <img src="/assets/images/isc/elcio-abdalla.png" alt="Elcio Abdalla" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Elcio Abdalla</h5>
                                     <p class="card-text text-muted"><a href="mailto:eabdalla@if.usp.br">eabdalla@if.usp.br</a></p>
@@ -103,7 +103,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/rong-gen-cai.png" alt="Rong-gen Cai" class="member-avatar">
+                                <img src="/assets/images/isc/rong-gen-cai.png" alt="Rong-gen Cai" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Rong-gen Cai</h5>
                                     <p class="card-text text-muted"><a href="mailto:cairg@itp.ac.cn">cairg@itp.ac.cn</a></p>
@@ -114,7 +114,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/anzhong-wang.png" alt="Anzhong Wang" class="member-avatar">
+                                <img src="/assets/images/isc/anzhong-wang.png" alt="Anzhong Wang" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Anzhong Wang</h5>
                                     <p class="card-text text-muted"><a href="mailto:Anzhong_Wang@baylor.edu">Anzhong_Wang@baylor.edu</a></p>
@@ -125,7 +125,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/mohammad-sami.png" alt="Mohammad Sami" class="member-avatar">
+                                <img src="/assets/images/isc/mohammad-sami.png" alt="Mohammad Sami" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Mohammad Sami</h5>
                                     <p class="card-text text-muted"><a href="mailto:samijamia@gmail.com">samijamia@gmail.com</a></p>
@@ -136,7 +136,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/dmitri-galtsov.png" alt="Dmitri Galtsov" class="member-avatar">
+                                <img src="/assets/images/isc/dmitri-galtsov.png" alt="Dmitri Galtsov" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Dmitri Galtsov</h5>
                                     <p class="card-text text-muted"><a href="mailto:galtsov@phys.msu.ru">galtsov@phys.msu.ru</a></p>
@@ -147,7 +147,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/roy-maartens.png" alt="Roy Maartens" class="member-avatar">
+                                <img src="/assets/images/isc/roy-maartens.png" alt="Roy Maartens" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Roy Maartens</h5>
                                     <p class="card-text text-muted"><a href="mailto:roy.maartens@gmail.com">roy.maartens@gmail.com</a></p>
@@ -158,7 +158,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/jailson-alcaniz.png" alt="Jailson Alcaniz" class="member-avatar">
+                                <img src="/assets/images/isc/jailson-alcaniz.png" alt="Jailson Alcaniz" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Jailson Alcaniz</h5>
                                     <p class="card-text text-muted"><a href="mailto:alcaniz@on.br">alcaniz@on.br</a></p>
@@ -169,7 +169,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/jeff-murugan.png" alt="Jeff Murugan" class="member-avatar">
+                                <img src="/assets/images/isc/jeff-murugan.png" alt="Jeff Murugan" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Jeff Murugan</h5>
                                 </div>
@@ -179,7 +179,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/bin-wang.png" alt="Bin Wang" class="member-avatar">
+                                <img src="/assets/images/isc/bin-wang.png" alt="Bin Wang" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Bin Wang</h5>
                                     <p class="card-text text-muted"><a href="mailto:wangb@yzu.edu.cn">wangb@yzu.edu.cn</a></p>
@@ -190,7 +190,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/sang-pyo-kim.png" alt="Sang Pyo Kim" class="member-avatar">
+                                <img src="/assets/images/isc/sang-pyo-kim.png" alt="Sang Pyo Kim" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Sang Pyo Kim</h5>
                                     <p class="card-text text-muted"><a href="mailto:sangkim@ks.kunsan.ac.kr">sangkim@ks.kunsan.ac.kr</a></p>
@@ -201,7 +201,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/salvatore-capozziello.png" alt="Salvatore Capozziello" class="member-avatar">
+                                <img src="/assets/images/isc/salvatore-capozziello.png" alt="Salvatore Capozziello" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Salvatore Capozziello</h5>
                                 </div>
@@ -211,7 +211,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/isc/alan-guth.png" alt="Alan Guth" class="member-avatar">
+                                <img src="/assets/images/isc/alan-guth.png" alt="Alan Guth" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Alan Guth</h5>
                                     <p class="card-text text-muted"><a href="mailto:guth@ctp.mit.edu">guth@ctp.mit.edu</a></p>
@@ -229,7 +229,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/loc/alcides-vicente-de-mello.png" alt="Alcides Vicente de Mello" class="member-avatar">
+                                <img src="/assets/images/loc/alcides-vicente-de-mello.png" alt="Alcides Vicente de Mello" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Alcides Vicente de Mello</h5>
                                     <p class="card-text text-muted">USP - BINGO/ABDUS</p>
@@ -240,7 +240,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/loc/marini-nascimento-de-lima.png" alt="Marini Nascimento de Lima" class="member-avatar">
+                                <img src="/assets/images/loc/marini-nascimento-de-lima.png" alt="Marini Nascimento de Lima" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Marini Nascimento de Lima</h5>
                                     <p class="card-text text-muted">TS for the 'Esperança no Espaço' Project</p>
@@ -251,7 +251,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/loc/geovanni-fernandes-garcia.png" alt="Geovanni Fernandes Garcia" class="member-avatar">
+                                <img src="/assets/images/loc/geovanni-fernandes-garcia.png" alt="Geovanni Fernandes Garcia" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Geovanni Fernandes Garcia</h5>
                                     <p class="card-text text-muted">USP - BINGO/ABDUS</p>
@@ -262,7 +262,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/loc/jorge-gabriel-ramos.png" alt="Prof. Jorge Gabriel Ramos" class="member-avatar">
+                                <img src="/assets/images/loc/jorge-gabriel-ramos.png" alt="Prof. Jorge Gabriel Ramos" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Prof. Jorge Gabriel Ramos</h5>
                                 </div>
@@ -272,7 +272,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/loc/paulo-porfirio.png" alt="Prof. Paulo Porfírio" class="member-avatar">
+                                <img src="/assets/images/loc/paulo-porfirio.png" alt="Prof. Paulo Porfírio" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Prof. Paulo Porfírio</h5>
                                 </div>
@@ -282,7 +282,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/loc/albert-petrov.png" alt="Prof. Albert Petrov" class="member-avatar">
+                                <img src="/assets/images/loc/albert-petrov.png" alt="Prof. Albert Petrov" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Prof. Albert Petrov</h5>
                                 </div>
@@ -292,7 +292,7 @@
                     <div class="col-md-6 col-lg-4">
                         <div class="card card-committee-enhanced mb-4">
                             <div class="card-body">
-                                <img src="assets/images/loc/jose-roberto-nascimento.png" alt="Prof. José Roberto Nascimento" class="member-avatar">
+                                <img src="/assets/images/loc/jose-roberto-nascimento.png" alt="Prof. José Roberto Nascimento" class="member-avatar">
                                 <div class="member-info">
                                     <h5 class="card-title">Prof. José Roberto Nascimento</h5>
                                 </div>
@@ -307,7 +307,7 @@
     <!-- Footer -->
     <footer class="footer text-center">
         <div class="container">
-            <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
+            <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
             <p>&copy; 2024-2025 BRICS Association on Gravity, Astrophysics and Cosmology. All rights reserved.</p>
             <p>5th BRICS-AGAC Symposium | João Pessoa, Paraíba, Brazil | December 2025</p>
         </div>
@@ -316,6 +316,6 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <!-- Custom JS -->
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
 </body>
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -8,8 +8,8 @@
     <title>Contact Us | BRICS-AGAC 2025</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="icon" href="assets/images/favicon-placeholder.png" type="image/png">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="icon" href="/assets/images/favicon-placeholder.png" type="image/png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -31,8 +31,8 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="index.html">
-                <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
+            <a class="navbar-brand" href="/">
+                <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
                 <div class="brand-text-container">
                     <h5>BRICS-AGAC 2025</h5>
                     <span>João Pessoa, Brazil</span>
@@ -44,36 +44,36 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">Home</a>
+                        <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="committees.html">Committees</a>
+                        <a class="nav-link" href="/committees/">Committees</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="speakers.html">Speakers</a>
+                        <a class="nav-link" href="/speakers/">Speakers</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="programme.html">Programme</a>
+                        <a class="nav-link" href="/programme/">Programme</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="registration.html">Registration</a>
+                        <a class="nav-link" href="/registration/">Registration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="abstract-submission.html">Abstracts</a>
+                        <a class="nav-link" href="/abstract-submission/">Abstracts</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownLocalInfo" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Local Info
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownLocalInfo">
-                            <li><a class="dropdown-item" href="venue-travel.html">Venue & Travel</a></li>
-                            <li><a class="dropdown-item" href="accommodation.html">Accommodation</a></li>
-                            <li><a class="dropdown-item" href="explore-joao-pessoa.html">Explore João Pessoa</a></li>
-                            <li><a class="dropdown-item" href="bingo-program.html">BINGO Program</a></li>
+                            <li><a class="dropdown-item" href="/venue-travel/">Venue & Travel</a></li>
+                            <li><a class="dropdown-item" href="/accommodation/">Accommodation</a></li>
+                            <li><a class="dropdown-item" href="/explore-joao-pessoa/">Explore João Pessoa</a></li>
+                            <li><a class="dropdown-item" href="/bingo-program/">BINGO Program</a></li>
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">Contact</a>
+                        <a class="nav-link" href="/contact/">Contact</a>
                     </li>
                 </ul>
             </div>
@@ -144,7 +144,7 @@
     <!-- Footer -->
     <footer class="footer text-center">
         <div class="container">
-            <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
+            <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
             <p>&copy; 2024-2025 BRICS Association on Gravity, Astrophysics and Cosmology. All rights reserved.</p>
             <p>5th BRICS-AGAC Symposium | João Pessoa, Paraíba, Brazil | December 2025</p>
         </div>
@@ -153,6 +153,6 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <!-- Custom JS -->
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
 </body>
 </html>

--- a/explore-joao-pessoa/index.html
+++ b/explore-joao-pessoa/index.html
@@ -8,8 +8,8 @@
     <title>Explore João Pessoa | BRICS-AGAC 2025</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="icon" href="assets/images/favicon-placeholder.png" type="image/png">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="icon" href="/assets/images/favicon-placeholder.png" type="image/png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -25,8 +25,8 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="index.html">
-                <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
+            <a class="navbar-brand" href="/">
+                <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
                 <div class="brand-text-container">
                     <h5>BRICS-AGAC 2025</h5>
                     <span>João Pessoa, Brazil</span>
@@ -38,36 +38,36 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">Home</a>
+                        <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="committees.html">Committees</a>
+                        <a class="nav-link" href="/committees/">Committees</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="speakers.html">Speakers</a>
+                        <a class="nav-link" href="/speakers/">Speakers</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="programme.html">Programme</a>
+                        <a class="nav-link" href="/programme/">Programme</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="registration.html">Registration</a>
+                        <a class="nav-link" href="/registration/">Registration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="abstract-submission.html">Abstracts</a>
+                        <a class="nav-link" href="/abstract-submission/">Abstracts</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownLocalInfo" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Local Info
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownLocalInfo">
-                            <li><a class="dropdown-item" href="venue-travel.html">Venue & Travel</a></li>
-                            <li><a class="dropdown-item" href="accommodation.html">Accommodation</a></li>
-                            <li><a class="dropdown-item" href="explore-joao-pessoa.html">Explore João Pessoa</a></li>
-                            <li><a class="dropdown-item" href="bingo-program.html">BINGO Program</a></li>
+                            <li><a class="dropdown-item" href="/venue-travel/">Venue & Travel</a></li>
+                            <li><a class="dropdown-item" href="/accommodation/">Accommodation</a></li>
+                            <li><a class="dropdown-item" href="/explore-joao-pessoa/">Explore João Pessoa</a></li>
+                            <li><a class="dropdown-item" href="/bingo-program/">BINGO Program</a></li>
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">Contact</a>
+                        <a class="nav-link" href="/contact/">Contact</a>
                     </li>
                 </ul>
             </div>
@@ -91,7 +91,7 @@
                 <!-- Attraction Card 1: Tambaú Beach -->
                 <div class="col-md-6 col-lg-4 mb-4">
                     <div class="card attraction-card h-100">
-                        <img src="assets/images/jp-tambau.jpg" class="card-img-top" alt="Tambaú Beach">
+                        <img src="/assets/images/jp-tambau.jpg" class="card-img-top" alt="Tambaú Beach">
                         <div class="card-body">
                             <h2 class="card-title h5">Tambaú Beach (Praia de Tambaú)</h2>
                             <p class="card-text">One of the city's main urban beaches, bustling with activity, beachfront restaurants, and artisan shops. Perfect for a stroll or enjoying fresh coconut water.</p>
@@ -102,7 +102,7 @@
                 <!-- Attraction Card 2: Cabo Branco Lighthouse -->
                 <div class="col-md-6 col-lg-4 mb-4">
                     <div class="card attraction-card h-100">
-                        <img src="assets/images/jp-farol.jpg" class="card-img-top" alt="Cabo Branco Lighthouse">
+                        <img src="/assets/images/jp-farol.jpg" class="card-img-top" alt="Cabo Branco Lighthouse">
                         <div class="card-body">
                             <h2 class="card-title h5">Cabo Branco Lighthouse (Farol do Cabo Branco)</h2>
                             <p class="card-text">An iconic lighthouse marking the easternmost point of continental Brazil (before Ponta do Seixas). Offers panoramic views of the coastline.</p>
@@ -113,7 +113,7 @@
                 <!-- Attraction Card 3: Ponta do Seixas -->
                 <div class="col-md-6 col-lg-4 mb-4">
                     <div class="card attraction-card h-100">
-                        <img src="assets/images/jp-seixas.jpg" class="card-img-top" alt="Ponta do Seixas">
+                        <img src="/assets/images/jp-seixas.jpg" class="card-img-top" alt="Ponta do Seixas">
                         <div class="card-body">
                             <h2 class="card-title h5">Ponta do Seixas</h2>
                             <p class="card-text">The true easternmost point of the Americas. Visit at sunrise to be among the first to see the sun on the continent. Nearby natural pools (Piscinas Naturais do Seixas) are accessible at low tide.</p>
@@ -124,7 +124,7 @@
                 <!-- Attraction Card 4: Historic Center -->
                 <div class="col-md-6 col-lg-4 mb-4">
                     <div class="card attraction-card h-100">
-                        <img src="assets/images/jp-historic-center-placeholder.jpg" class="card-img-top" alt="Historic Center of João Pessoa">
+                        <img src="/assets/images/jp-historic-center-placeholder.jpg" class="card-img-top" alt="Historic Center of João Pessoa">
                         <div class="card-body">
                             <h2 class="card-title h5">Historic Center (Centro Histórico)</h2>
                             <p class="card-text">Explore colonial architecture, including the São Francisco Cultural Center (a baroque masterpiece), churches, and charming squares like Praça Antenor Navarro.</p>
@@ -135,7 +135,7 @@
                 <!-- Attraction Card 5: Estação Cabo Branco -->
                 <div class="col-md-6 col-lg-4 mb-4">
                     <div class="card attraction-card h-100">
-                        <img src="assets/images/jp-estacao-cabo-branco-placeholder.jpg" class="card-img-top" alt="Estação Cabo Branco">
+                        <img src="/assets/images/jp-estacao-cabo-branco-placeholder.jpg" class="card-img-top" alt="Estação Cabo Branco">
                         <div class="card-body">
                             <h2 class="card-title h5">Estação Cabo Branco – Ciência, Cultura e Artes</h2>
                             <p class="card-text">A cultural complex designed by Oscar Niemeyer, featuring exhibitions on science, art, and technology, plus an observation tower with stunning city views.</p>
@@ -146,7 +146,7 @@
                 <!-- Attraction Card 6: Areia Vermelha -->
                 <div class="col-md-6 col-lg-4 mb-4">
                     <div class="card attraction-card h-100">
-                        <img src="assets/images/jp-areia-vermelha-placeholder.jpg" class="card-img-top" alt="Areia Vermelha">
+                        <img src="/assets/images/jp-areia-vermelha-placeholder.jpg" class="card-img-top" alt="Areia Vermelha">
                         <div class="card-body">
                             <h2 class="card-title h5">Areia Vermelha Island</h2>
                             <p class="card-text">A temporary sandbar island that appears at low tide, accessible by boat. Offers clear waters for swimming and snorkeling. A popular day trip.</p>
@@ -166,7 +166,7 @@
     <!-- Footer -->
     <footer class="footer text-center">
         <div class="container">
-            <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
+            <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
             <p>&copy; 2024-2025 BRICS Association on Gravity, Astrophysics and Cosmology. All rights reserved.</p>
             <p>5th BRICS-AGAC Symposium | João Pessoa, Paraíba, Brazil | December 2025</p>
         </div>
@@ -175,6 +175,6 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <!-- Custom JS -->
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
     <title>BRICS-AGAC 2025 | 5th Symposium | João Pessoa, Brazil</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="icon" href="assets/images/favicon-placeholder.png" type="image/png">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="icon" href="/assets/images/favicon-placeholder.png" type="image/png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -52,8 +52,8 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="index.html">
-                <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
+            <a class="navbar-brand" href="/">
+                <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
                 <div class="brand-text-container">
                     <h5>BRICS-AGAC 2025</h5>
                     <span>João Pessoa, Brazil</span>
@@ -65,36 +65,36 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">Home</a>
+                        <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="committees.html">Committees</a>
+                        <a class="nav-link" href="/committees/">Committees</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="speakers.html">Speakers</a>
+                        <a class="nav-link" href="/speakers/">Speakers</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="programme.html">Programme</a>
+                        <a class="nav-link" href="/programme/">Programme</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="registration.html">Registration</a>
+                        <a class="nav-link" href="/registration/">Registration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="abstract-submission.html">Abstracts</a>
+                        <a class="nav-link" href="/abstract-submission/">Abstracts</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownLocalInfo" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Local Info
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownLocalInfo">
-                            <li><a class="dropdown-item" href="venue-travel.html">Venue & Travel</a></li>
-                            <li><a class="dropdown-item" href="accommodation.html">Accommodation</a></li>
-                            <li><a class="dropdown-item" href="explore-joao-pessoa.html">Explore João Pessoa</a></li>
-                            <li><a class="dropdown-item" href="bingo-program.html">BINGO Program</a></li>
+                            <li><a class="dropdown-item" href="/venue-travel/">Venue & Travel</a></li>
+                            <li><a class="dropdown-item" href="/accommodation/">Accommodation</a></li>
+                            <li><a class="dropdown-item" href="/explore-joao-pessoa/">Explore João Pessoa</a></li>
+                            <li><a class="dropdown-item" href="/bingo-program/">BINGO Program</a></li>
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">Contact</a>
+                        <a class="nav-link" href="/contact/">Contact</a>
                     </li>
                 </ul>
             </div>
@@ -107,8 +107,8 @@
             <h1>5th BRICS-AGAC Symposium 2025</h1>
             <p class="lead date-location"><i class="fas fa-map-marker-alt"></i> João Pessoa, Paraíba, Brazil</p>
             <p class="lead date-location"><i class="fas fa-calendar-alt"></i> December 9-12, 2025</p>
-            <a href="registration.html" class="btn btn-primary btn-lg me-2 mt-3">Register Now</a>
-            <a href="programme.html" class="btn btn-secondary btn-lg mt-3">View Programme</a>
+            <a href="/registration/" class="btn btn-primary btn-lg me-2 mt-3">Register Now</a>
+            <a href="/programme/" class="btn btn-secondary btn-lg mt-3">View Programme</a>
         </div>
     </header>
 
@@ -186,15 +186,15 @@
             <div class="container text-center">
                 <h2 class="mb-5">Organizers & Supporters</h2>
                 <h4 class="mb-3">Host Institution</h4>
-                <p><img src="assets/images/logo-ufpb.png" alt="Federal University of Paraíba Logo" style="max-height: 80px;"> Federal University of Paraíba (UFPB)</p>
+                <p><img src="/assets/images/logo-ufpb.png" alt="Federal University of Paraíba Logo" style="max-height: 80px;"> Federal University of Paraíba (UFPB)</p>
                 <p class="text-muted">(The exact auditorium will be announced soon)</p>
 
                 <h4 class="mt-5 mb-3">Organized by</h4>
-                <p><img src="assets/images/logo-brics-agac-2025.png" alt="BRICS AGAC Logo" style="max-height: 80px;"> BRICS Association on Gravity, Astrophysics and Cosmology</p>
+                <p><img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS AGAC Logo" style="max-height: 80px;"> BRICS Association on Gravity, Astrophysics and Cosmology</p>
 
                 <h4 class="mt-5 mb-3">Supported by</h4>
                 <div class="organizers-logos d-flex flex-wrap justify-content-center align-items-center">
-                    <img src="assets/images/secties.png" alt="SECTIES Logo" style="max-height: 80px;">
+                    <img src="/assets/images/secties.png" alt="SECTIES Logo" style="max-height: 80px;">
                     <!-- Add more sponsor logos as needed -->
                 </div>
                 <p class="mt-3">SECTIES (State Secretariat for Science, Technology, Innovation and Higher Education of Paraíba)</p>
@@ -205,7 +205,7 @@
     <!-- Footer -->
     <footer class="footer text-center">
         <div class="container">
-            <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
+            <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
             <p>&copy; 2024-2025 BRICS Association on Gravity, Astrophysics and Cosmology. All rights reserved.</p>
             <p>5th BRICS-AGAC Symposium | João Pessoa, Paraíba, Brazil | December 2025</p>
         </div>
@@ -214,6 +214,6 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <!-- Custom JS -->
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
 </body>
 </html>

--- a/programme/index.html
+++ b/programme/index.html
@@ -4,19 +4,19 @@
     <!-- Common Header Content -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Invited speakers for BRICS-AGAC 2025.">
-    <title>Invited Speakers | BRICS-AGAC 2025</title>
+    <meta name="description" content="Conference programme for BRICS-AGAC 2025.">
+    <title>Programme | BRICS-AGAC 2025</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="icon" href="assets/images/favicon-placeholder.png" type="image/png">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="icon" href="/assets/images/favicon-placeholder.png" type="image/png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Invited Speakers | BRICS-AGAC 2025",
-      "url": "https://bricsagac.com.br/speakers.html",
-      "description": "Invited speakers for BRICS-AGAC 2025."
+      "name": "Programme | BRICS-AGAC 2025",
+      "url": "https://bricsagac.com.br/programme.html",
+      "description": "Conference programme for BRICS-AGAC 2025."
     }
     </script>
 </head>
@@ -25,8 +25,8 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="index.html">
-                <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
+            <a class="navbar-brand" href="/">
+                <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
                 <div class="brand-text-container">
                     <h5>BRICS-AGAC 2025</h5>
                     <span>João Pessoa, Brazil</span>
@@ -38,36 +38,36 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">Home</a>
+                        <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="committees.html">Committees</a>
+                        <a class="nav-link" href="/committees/">Committees</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="speakers.html">Speakers</a>
+                        <a class="nav-link" href="/speakers/">Speakers</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="programme.html">Programme</a>
+                        <a class="nav-link" href="/programme/">Programme</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="registration.html">Registration</a>
+                        <a class="nav-link" href="/registration/">Registration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="abstract-submission.html">Abstracts</a>
+                        <a class="nav-link" href="/abstract-submission/">Abstracts</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownLocalInfo" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Local Info
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownLocalInfo">
-                            <li><a class="dropdown-item" href="venue-travel.html">Venue & Travel</a></li>
-                            <li><a class="dropdown-item" href="accommodation.html">Accommodation</a></li>
-                            <li><a class="dropdown-item" href="explore-joao-pessoa.html">Explore João Pessoa</a></li>
-                            <li><a class="dropdown-item" href="bingo-program.html">BINGO Program</a></li>
+                            <li><a class="dropdown-item" href="/venue-travel/">Venue & Travel</a></li>
+                            <li><a class="dropdown-item" href="/accommodation/">Accommodation</a></li>
+                            <li><a class="dropdown-item" href="/explore-joao-pessoa/">Explore João Pessoa</a></li>
+                            <li><a class="dropdown-item" href="/bingo-program/">BINGO Program</a></li>
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">Contact</a>
+                        <a class="nav-link" href="/contact/">Contact</a>
                     </li>
                 </ul>
             </div>
@@ -77,8 +77,8 @@
     <!-- Page Header -->
     <header class="page-header text-center">
         <div class="container">
-            <h1>Invited Speakers</h1>
-            <p class="lead">Esteemed experts sharing their insights at BRICS-AGAC 2025.</p>
+            <h1>Conference Programme</h1>
+            <p class="lead">Schedule of events for BRICS-AGAC 2025.</p>
         </div>
     </header>
 
@@ -87,16 +87,28 @@
         <div class="container">
             <div class="row">
                 <div class="col-12 text-center">
-                    <h3>Speakers will be announced soon.</h3>
+                    <h3>Programme will be announced soon.</h3>
                 </div>
             </div>
         </div>
     </main>
+    <!--
+    <section id="coffee-break-menu" class="mt-5">
+        <h2 class="text-center page-section-header mb-4">Coffee Break Menu</h2>
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                <p><strong>Savory and Sweet Snacks:</strong> Cake (orange, chocolate, cassava and mixed), Delicious chicken roll, Cheese pie, Delicious cheese roll, Sweetened meat pastry, Mini turkey and chicken sandwich, Chicken coxinha, Swiss roll (lemon, chocolate, dulce de leche and guava), Cookies, Toast, Fruit salad, Jelly.</p>
+                <p><strong>Beverages:</strong> Juices (caju, acerola and cajá), Coffee.</p>
+                <p><strong>Additional Services:</strong> Cups, plates, napkins, sweetener and sugar.</p>
+            </div>
+        </div>
+    </section>
+    -->
 
     <!-- Footer -->
     <footer class="footer text-center">
         <div class="container">
-            <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
+            <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
             <p>&copy; 2024-2025 BRICS Association on Gravity, Astrophysics and Cosmology. All rights reserved.</p>
             <p>5th BRICS-AGAC Symposium | João Pessoa, Paraíba, Brazil | December 2025</p>
         </div>
@@ -105,6 +117,6 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <!-- Custom JS -->
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
 </body>
 </html>

--- a/registration/index.html
+++ b/registration/index.html
@@ -8,8 +8,8 @@
     <title>Registration | BRICS-AGAC 2025</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="icon" href="assets/images/favicon-placeholder.png" type="image/png">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="icon" href="/assets/images/favicon-placeholder.png" type="image/png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -25,8 +25,8 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="index.html">
-                <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
+            <a class="navbar-brand" href="/">
+                <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
                 <div class="brand-text-container">
                     <h5>BRICS-AGAC 2025</h5>
                     <span>João Pessoa, Brazil</span>
@@ -38,36 +38,36 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">Home</a>
+                        <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="committees.html">Committees</a>
+                        <a class="nav-link" href="/committees/">Committees</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="speakers.html">Speakers</a>
+                        <a class="nav-link" href="/speakers/">Speakers</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="programme.html">Programme</a>
+                        <a class="nav-link" href="/programme/">Programme</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="registration.html">Registration</a>
+                        <a class="nav-link" href="/registration/">Registration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="abstract-submission.html">Abstracts</a>
+                        <a class="nav-link" href="/abstract-submission/">Abstracts</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownLocalInfo" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Local Info
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownLocalInfo">
-                            <li><a class="dropdown-item" href="venue-travel.html">Venue & Travel</a></li>
-                            <li><a class="dropdown-item" href="accommodation.html">Accommodation</a></li>
-                            <li><a class="dropdown-item" href="explore-joao-pessoa.html">Explore João Pessoa</a></li>
-                            <li><a class="dropdown-item" href="bingo-program.html">BINGO Program</a></li>
+                            <li><a class="dropdown-item" href="/venue-travel/">Venue & Travel</a></li>
+                            <li><a class="dropdown-item" href="/accommodation/">Accommodation</a></li>
+                            <li><a class="dropdown-item" href="/explore-joao-pessoa/">Explore João Pessoa</a></li>
+                            <li><a class="dropdown-item" href="/bingo-program/">BINGO Program</a></li>
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">Contact</a>
+                        <a class="nav-link" href="/contact/">Contact</a>
                     </li>
                 </ul>
             </div>
@@ -142,7 +142,7 @@
     <!-- Footer -->
     <footer class="footer text-center">
         <div class="container">
-            <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
+            <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
             <p>&copy; 2024-2025 BRICS Association on Gravity, Astrophysics and Cosmology. All rights reserved.</p>
             <p>5th BRICS-AGAC Symposium | João Pessoa, Paraíba, Brazil | December 2025</p>
         </div>
@@ -151,6 +151,6 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <!-- Custom JS -->
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
 </body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,67 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://bricsagac.com.br/index.html</loc>
+    <loc>https://bricsagac.com.br/</loc>
     <lastmod>2025-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://bricsagac.com.br/committees.html</loc>
+    <loc>https://bricsagac.com.br/committees/</loc>
     <lastmod>2025-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://bricsagac.com.br/speakers.html</loc>
+    <loc>https://bricsagac.com.br/speakers/</loc>
     <lastmod>2025-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://bricsagac.com.br/programme.html</loc>
+    <loc>https://bricsagac.com.br/programme/</loc>
     <lastmod>2025-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://bricsagac.com.br/registration.html</loc>
+    <loc>https://bricsagac.com.br/registration/</loc>
     <lastmod>2025-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://bricsagac.com.br/abstract-submission.html</loc>
+    <loc>https://bricsagac.com.br/abstract-submission/</loc>
     <lastmod>2025-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://bricsagac.com.br/venue-travel.html</loc>
+    <loc>https://bricsagac.com.br/venue-travel/</loc>
     <lastmod>2025-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://bricsagac.com.br/accommodation.html</loc>
+    <loc>https://bricsagac.com.br/accommodation/</loc>
     <lastmod>2025-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://bricsagac.com.br/explore-joao-pessoa.html</loc>
+    <loc>https://bricsagac.com.br/explore-joao-pessoa/</loc>
     <lastmod>2025-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://bricsagac.com.br/bingo-program.html</loc>
+    <loc>https://bricsagac.com.br/bingo-program/</loc>
     <lastmod>2025-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://bricsagac.com.br/contact.html</loc>
+    <loc>https://bricsagac.com.br/contact/</loc>
     <lastmod>2025-08-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>

--- a/speakers/index.html
+++ b/speakers/index.html
@@ -4,19 +4,19 @@
     <!-- Common Header Content -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Conference programme for BRICS-AGAC 2025.">
-    <title>Programme | BRICS-AGAC 2025</title>
+    <meta name="description" content="Invited speakers for BRICS-AGAC 2025.">
+    <title>Invited Speakers | BRICS-AGAC 2025</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="icon" href="assets/images/favicon-placeholder.png" type="image/png">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="icon" href="/assets/images/favicon-placeholder.png" type="image/png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Programme | BRICS-AGAC 2025",
-      "url": "https://bricsagac.com.br/programme.html",
-      "description": "Conference programme for BRICS-AGAC 2025."
+      "name": "Invited Speakers | BRICS-AGAC 2025",
+      "url": "https://bricsagac.com.br/speakers.html",
+      "description": "Invited speakers for BRICS-AGAC 2025."
     }
     </script>
 </head>
@@ -25,8 +25,8 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="index.html">
-                <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
+            <a class="navbar-brand" href="/">
+                <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
                 <div class="brand-text-container">
                     <h5>BRICS-AGAC 2025</h5>
                     <span>João Pessoa, Brazil</span>
@@ -38,36 +38,36 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">Home</a>
+                        <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="committees.html">Committees</a>
+                        <a class="nav-link" href="/committees/">Committees</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="speakers.html">Speakers</a>
+                        <a class="nav-link" href="/speakers/">Speakers</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="programme.html">Programme</a>
+                        <a class="nav-link" href="/programme/">Programme</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="registration.html">Registration</a>
+                        <a class="nav-link" href="/registration/">Registration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="abstract-submission.html">Abstracts</a>
+                        <a class="nav-link" href="/abstract-submission/">Abstracts</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownLocalInfo" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Local Info
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownLocalInfo">
-                            <li><a class="dropdown-item" href="venue-travel.html">Venue & Travel</a></li>
-                            <li><a class="dropdown-item" href="accommodation.html">Accommodation</a></li>
-                            <li><a class="dropdown-item" href="explore-joao-pessoa.html">Explore João Pessoa</a></li>
-                            <li><a class="dropdown-item" href="bingo-program.html">BINGO Program</a></li>
+                            <li><a class="dropdown-item" href="/venue-travel/">Venue & Travel</a></li>
+                            <li><a class="dropdown-item" href="/accommodation/">Accommodation</a></li>
+                            <li><a class="dropdown-item" href="/explore-joao-pessoa/">Explore João Pessoa</a></li>
+                            <li><a class="dropdown-item" href="/bingo-program/">BINGO Program</a></li>
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">Contact</a>
+                        <a class="nav-link" href="/contact/">Contact</a>
                     </li>
                 </ul>
             </div>
@@ -77,8 +77,8 @@
     <!-- Page Header -->
     <header class="page-header text-center">
         <div class="container">
-            <h1>Conference Programme</h1>
-            <p class="lead">Schedule of events for BRICS-AGAC 2025.</p>
+            <h1>Invited Speakers</h1>
+            <p class="lead">Esteemed experts sharing their insights at BRICS-AGAC 2025.</p>
         </div>
     </header>
 
@@ -87,28 +87,16 @@
         <div class="container">
             <div class="row">
                 <div class="col-12 text-center">
-                    <h3>Programme will be announced soon.</h3>
+                    <h3>Speakers will be announced soon.</h3>
                 </div>
             </div>
         </div>
     </main>
-    <!--
-    <section id="coffee-break-menu" class="mt-5">
-        <h2 class="text-center page-section-header mb-4">Coffee Break Menu</h2>
-        <div class="row justify-content-center">
-            <div class="col-lg-8">
-                <p><strong>Savory and Sweet Snacks:</strong> Cake (orange, chocolate, cassava and mixed), Delicious chicken roll, Cheese pie, Delicious cheese roll, Sweetened meat pastry, Mini turkey and chicken sandwich, Chicken coxinha, Swiss roll (lemon, chocolate, dulce de leche and guava), Cookies, Toast, Fruit salad, Jelly.</p>
-                <p><strong>Beverages:</strong> Juices (caju, acerola and cajá), Coffee.</p>
-                <p><strong>Additional Services:</strong> Cups, plates, napkins, sweetener and sugar.</p>
-            </div>
-        </div>
-    </section>
-    -->
 
     <!-- Footer -->
     <footer class="footer text-center">
         <div class="container">
-            <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
+            <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
             <p>&copy; 2024-2025 BRICS Association on Gravity, Astrophysics and Cosmology. All rights reserved.</p>
             <p>5th BRICS-AGAC Symposium | João Pessoa, Paraíba, Brazil | December 2025</p>
         </div>
@@ -117,6 +105,6 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <!-- Custom JS -->
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
 </body>
 </html>

--- a/venue-travel/index.html
+++ b/venue-travel/index.html
@@ -8,8 +8,8 @@
     <title>Venue & Travel | BRICS-AGAC 2025</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="css/style.css">
-    <link rel="icon" href="assets/images/favicon-placeholder.png" type="image/png">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="icon" href="/assets/images/favicon-placeholder.png" type="image/png">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -25,8 +25,8 @@
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="index.html">
-                <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
+            <a class="navbar-brand" href="/">
+                <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Logo">
                 <div class="brand-text-container">
                     <h5>BRICS-AGAC 2025</h5>
                     <span>João Pessoa, Brazil</span>
@@ -38,36 +38,36 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">Home</a>
+                        <a class="nav-link" href="/">Home</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="committees.html">Committees</a>
+                        <a class="nav-link" href="/committees/">Committees</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="speakers.html">Speakers</a>
+                        <a class="nav-link" href="/speakers/">Speakers</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="programme.html">Programme</a>
+                        <a class="nav-link" href="/programme/">Programme</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="registration.html">Registration</a>
+                        <a class="nav-link" href="/registration/">Registration</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="abstract-submission.html">Abstracts</a>
+                        <a class="nav-link" href="/abstract-submission/">Abstracts</a>
                     </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownLocalInfo" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             Local Info
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownLocalInfo">
-                            <li><a class="dropdown-item" href="venue-travel.html">Venue & Travel</a></li>
-                            <li><a class="dropdown-item" href="accommodation.html">Accommodation</a></li>
-                            <li><a class="dropdown-item" href="explore-joao-pessoa.html">Explore João Pessoa</a></li>
-                            <li><a class="dropdown-item" href="bingo-program.html">BINGO Program</a></li>
+                            <li><a class="dropdown-item" href="/venue-travel/">Venue & Travel</a></li>
+                            <li><a class="dropdown-item" href="/accommodation/">Accommodation</a></li>
+                            <li><a class="dropdown-item" href="/explore-joao-pessoa/">Explore João Pessoa</a></li>
+                            <li><a class="dropdown-item" href="/bingo-program/">BINGO Program</a></li>
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">Contact</a>
+                        <a class="nav-link" href="/contact/">Contact</a>
                     </li>
                 </ul>
             </div>
@@ -148,20 +148,20 @@
                 <h4 class="mt-4 mb-3">On-Campus at UFPB</h4>
                 <div class="row">
                     <div class="col-md-4">
-                        <img src="assets/images/restaurant_ru_ufpb.png" class="img-fluid rounded mb-2" alt="Restaurante Universitário (RU)">
+                        <img src="/assets/images/restaurant_ru_ufpb.png" class="img-fluid rounded mb-2" alt="Restaurante Universitário (RU)">
                         <h5>Restaurante Universitário (RU)</h5>
                         <p><strong>Address:</strong> R. Ver. João Freire - Castelo Branco, João Pessoa - PB, 58050-585<br>
                         <strong>Phone:</strong> +55 (83) 3216-7876<br>
                         <em>Note: The organizing committee is exploring the possibility of providing free lunch vouchers for participants.</em></p>
                     </div>
                     <div class="col-md-4">
-                        <img src="assets/images/restaurant_dona_help.png" class="img-fluid rounded mb-2" alt="Dona Help">
+                        <img src="/assets/images/restaurant_dona_help.png" class="img-fluid rounded mb-2" alt="Dona Help">
                         <h5>Dona Help</h5>
                         <p><strong>Address:</strong> Via Expressa Padre Zé, 173 - Castelo Branco III, João Pessoa - PB<br>
                         <strong>Phone:</strong> +55 (83) 98230-2504</p>
                     </div>
                     <div class="col-md-4">
-                        <img src="assets/images/restaurant_cozinha_caseira.png" class="img-fluid rounded mb-2" alt="Cozinha Caseira">
+                        <img src="/assets/images/restaurant_cozinha_caseira.png" class="img-fluid rounded mb-2" alt="Cozinha Caseira">
                         <h5>Cozinha Caseira (near Central de Aulas)</h5>
                         <p><strong>Address:</strong> Via Ipê Amarelo, Próximo a - Castelo Branco, João Pessoa - PB, 58051-900<br>
                         <strong>Phone:</strong> +55 (83) 99637-3969</p>
@@ -171,25 +171,25 @@
                 <h4 class="mt-4 mb-3">Off-Campus (Bancários Neighborhood)</h4>
                 <div class="row">
                     <div class="col-md-4">
-                        <img src="assets/images/restaurant_coelhos.png" class="img-fluid rounded mb-2" alt="Coelho's Restaurante">
+                        <img src="/assets/images/restaurant_coelhos.png" class="img-fluid rounded mb-2" alt="Coelho's Restaurante">
                         <h5>Coelho's Restaurante</h5>
                         <p><strong>Address:</strong> R. Djalma Coelho, 20 - Bancários, João Pessoa - PB, 58051-124<br>
                         <strong>Phone:</strong> +55 (83) 3235-2859</p>
                     </div>
                     <div class="col-md-4">
-                        <img src="assets/images/restaurant_domani.png" class="img-fluid rounded mb-2" alt="Domani Restaurante">
+                        <img src="/assets/images/restaurant_domani.png" class="img-fluid rounded mb-2" alt="Domani Restaurante">
                         <h5>Domani Restaurante</h5>
                         <p><strong>Address:</strong> R. Empresário João Rodrigues Alves, 360 - Jardim Sao Paulo, João Pessoa - PB, 58051-000<br>
                         <strong>Phone:</strong> +55 (83) 3235-5858</p>
                     </div>
                     <div class="col-md-4">
-                        <img src="assets/images/restaurant_felipe.png" class="img-fluid rounded mb-2" alt="Felipe Restaurante">
+                        <img src="/assets/images/restaurant_felipe.png" class="img-fluid rounded mb-2" alt="Felipe Restaurante">
                         <h5>Felipe Restaurante</h5>
                         <p><strong>Address:</strong> Contorno da UFPB - R. José Serrano Navarro, 424 - Castelo Branco, João Pessoa - PB, 58050-580<br>
                         <strong>Phone:</strong> +55 (83) 99628-9735</p>
                     </div>
                     <div class="col-md-4">
-                        <img src="assets/images/restaurant_mariwo_bistro.png" class="img-fluid rounded mb-2" alt="Bistrô Mariwô">
+                        <img src="/assets/images/restaurant_mariwo_bistro.png" class="img-fluid rounded mb-2" alt="Bistrô Mariwô">
                         <h5>Bistrô Mariwô</h5>
                         <p><strong>Address:</strong> R. Onaldo da Silva Coutinho, 191 - Castelo Branco III, João Pessoa - PB, 58050-600<br>
                         <strong>Phone:</strong> +55 (83) 98781-7067</p>
@@ -202,7 +202,7 @@
     <!-- Footer -->
     <footer class="footer text-center">
         <div class="container">
-            <img src="assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
+            <img src="/assets/images/logo-brics-agac-2025.png" alt="BRICS-AGAC 2025 Small Logo" class="footer-logo">
             <p>&copy; 2024-2025 BRICS Association on Gravity, Astrophysics and Cosmology. All rights reserved.</p>
             <p>5th BRICS-AGAC Symposium | João Pessoa, Paraíba, Brazil | December 2025</p>
         </div>
@@ -211,6 +211,6 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <!-- Custom JS -->
-    <script src="js/script.js"></script>
+    <script src="/js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit refactors the entire site structure to use "clean URLs" (e.g., `/committees/` instead of `/committees.html`).

This involved three main actions:
1.  **File Restructuring**: Each HTML page (except the main `index.html`) was moved into a dedicated folder and renamed to `index.html`.
2.  **Global Link Updates**: All internal `href` attributes in `<a>` tags and asset paths (for CSS, JS, and images) were updated to be root-relative and point to the new directory structure.
3.  **SEO File Updates**: The `sitemap.xml` was updated to reflect the new clean URLs, ensuring that search engines can discover the new structure.