### PR TITLE
feat: Temporarily remove 'Shirts' page

### DIFF
--- a/abstract-submission/index.html
+++ b/abstract-submission/index.html
@@ -76,11 +76,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip

--- a/accommodation/index.html
+++ b/accommodation/index.html
@@ -77,11 +77,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip

--- a/bingo-program/index.html
+++ b/bingo-program/index.html
@@ -71,11 +71,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link active" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip

--- a/committees/index.html
+++ b/committees/index.html
@@ -76,11 +76,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip

--- a/contact/index.html
+++ b/contact/index.html
@@ -82,11 +82,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip

--- a/explore-joao-pessoa/index.html
+++ b/explore-joao-pessoa/index.html
@@ -76,11 +76,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip

--- a/index.html
+++ b/index.html
@@ -103,11 +103,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip

--- a/programme/index.html
+++ b/programme/index.html
@@ -76,11 +76,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip

--- a/registration/index.html
+++ b/registration/index.html
@@ -71,11 +71,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip

--- a/shirts/index.html
+++ b/shirts/index.html
@@ -1,3 +1,4 @@
+<!--
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -64,11 +65,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link active" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip
@@ -410,3 +411,4 @@
     <script src="/js/shirts-form.js"></script>
 </body>
 </html>
+-->

--- a/shirts/thank-you.html
+++ b/shirts/thank-you.html
@@ -1,3 +1,4 @@
+<!--
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -61,11 +62,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip
@@ -155,3 +156,4 @@
     <script src="/js/script.js"></script>
 </body>
 </html>
+-->

--- a/speakers/index.html
+++ b/speakers/index.html
@@ -76,11 +76,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip

--- a/venue-travel/index.html
+++ b/venue-travel/index.html
@@ -76,11 +76,11 @@
         </li>
        </ul>
       </li>
-      <li class="nav-item">
+      <!-- <li class="nav-item">
        <a class="nav-link" data-lang-en="Shirts" data-lang-pt="Camisetas" href="/shirts/">
         Shirts
        </a>
-      </li>
+      </li> -->
       <li class="nav-item">
        <a class="nav-link" data-lang-en="BINGO Trip" data-lang-pt="Viagem ao BINGO" href="/bingo-program/">
         BINGO Trip


### PR DESCRIPTION
This commit temporarily removes the 'Shirts' page from the live site as requested.

The entire content of `shirts/index.html` and `shirts/thank-you.html` has been commented out, preserving the code for future use.

The navigation link to the 'Shirts' page has also been commented out from the header in all HTML files to hide it from the user interface.

Frontend verification was performed to confirm the link is no longer visible.