### PR TITLE
Adds talk titles for specified speakers on the speakers page.

### DIFF
--- a/speakers/index.html
+++ b/speakers/index.html
@@ -169,7 +169,7 @@
         <div class="card-body text-center">
          <h5 class="card-title">Chen Bin</h5>
          <p class="text-muted" data-lang-en="Affiliation to be announced" data-lang-pt="Afiliação a ser anunciada">Affiliation to be announced</p>
-         <h6 class="card-subtitle mb-2 text-muted" data-lang-en="Talk title to be announced" data-lang-pt="Título da palestra a ser anunciado">Talk title to be announced</h6>
+         <h6 class="card-subtitle mb-2" data-lang-en="Near-Horizon Polarization as a diagnostic of black hole spacetime" data-lang-pt="Título da palestra a ser anunciado">Near-Horizon Polarization as a diagnostic of black hole spacetime</h6>
         </div>
        </div>
       </div>
@@ -196,7 +196,7 @@
         <div class="card-body text-center">
          <h5 class="card-title">Li li</h5>
          <p class="text-muted" data-lang-en="Affiliation to be announced" data-lang-pt="Afiliação a ser anunciada">Affiliation to be announced</p>
-         <h6 class="card-subtitle mb-2 text-muted" data-lang-en="Talk title to be announced" data-lang-pt="Título da palestra a ser anunciado">Talk title to be announced</h6>
+         <h6 class="card-subtitle mb-2" data-lang-en="Thermodynamics of charged magnetic black holes with Chern-Simons term" data-lang-pt="Título da palestra a ser anunciado">Thermodynamics of charged magnetic black holes with Chern-Simons term</h6>
         </div>
        </div>
       </div>
@@ -205,7 +205,7 @@
         <div class="card-body text-center">
          <h5 class="card-title">Yu-Xiao Liu</h5>
          <p class="text-muted" data-lang-en="Affiliation to be announced" data-lang-pt="Afiliação a ser anunciada">Affiliation to be announced</p>
-         <h6 class="card-subtitle mb-2 text-muted" data-lang-en="Talk title to be announced" data-lang-pt="Título da palestra a ser anunciado">Talk title to be announced</h6>
+         <h6 class="card-subtitle mb-2" data-lang-en="Polarization modes of gravitation waves" data-lang-pt="Título da palestra a ser anunciado">Polarization modes of gravitation waves</h6>
         </div>
        </div>
       </div>
@@ -214,7 +214,7 @@
         <div class="card-body text-center">
          <h5 class="card-title">Jiajun Zhang</h5>
          <p class="text-muted" data-lang-en="Affiliation to be announced" data-lang-pt="Afiliação a ser anunciada">Affiliation to be announced</p>
-         <h6 class="card-subtitle mb-2 text-muted" data-lang-en="Talk title to be announced" data-lang-pt="Título da palestra a ser anunciado">Talk title to be announced</h6>
+         <h6 class="card-subtitle mb-2" data-lang-en="The simulation and data processing pipeline for BINGO" data-lang-pt="Título da palestra a ser anunciado">The simulation and data processing pipeline for BINGO</h6>
         </div>
        </div>
       </div>
@@ -241,7 +241,7 @@
         <div class="card-body text-center">
          <h5 class="card-title">Yin-zhe Ma</h5>
          <p class="text-muted" data-lang-en="Affiliation to be announced" data-lang-pt="Afiliação a ser anunciada">Affiliation to be announced</p>
-         <h6 class="card-subtitle mb-2 text-muted" data-lang-en="Talk title to be announced" data-lang-pt="Título da palestra a ser anunciado">Talk title to be announced</h6>
+         <h6 class="card-subtitle mb-2" data-lang-en="Have we found all “missing baryons”in the cosmic web?" data-lang-pt="Título da palestra a ser anunciado">Have we found all “missing baryons”in the cosmic web?</h6>
         </div>
        </div>
       </div>


### PR DESCRIPTION
- Updates the HTML to include the talk titles for speakers who had them provided in the request.
- Enhances the visual presentation of the titles by removing the 'text-muted' class, making them more prominent.
- Preserves the Portuguese placeholder text for talk titles, as translations were not provided.