### PR TITLE
Add auto-scroll to Thank You section on homepage load

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -146,6 +146,15 @@ document.addEventListener('DOMContentLoaded', function() {
         scrollObserver.observe(element);
     });
 
+    // --- Auto-scroll to Thank You Section (Homepage) ---
+    const thankYouSection = document.querySelector('.thank-you-section');
+    if (thankYouSection) {
+        // Add a small delay to ensure initial layout and animations don't interfere with scroll position
+        setTimeout(() => {
+            thankYouSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }, 800);
+    }
+
 
     // --- Button Mouse-aware Spotlight Effect ---
     const buttons = document.querySelectorAll('.btn');


### PR DESCRIPTION
- Update js/script.js to check for the .thank-you-section and scroll to it after a short delay on page load.
- Ensure this behavior only triggers on the homepage.
- Verified functionality with Playwright script.